### PR TITLE
Update hadolint github action and set failure threshold

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v1.4.0
+      - uses: hadolint/hadolint-action@v1.5.0
+        with:
+          failure-threshold: error


### PR DESCRIPTION
By default the hadolint action fails at the "info" level, which complains about things like consecutive RUN commands.  This makes it fail at the same level as the pre-commit hook.