### PR TITLE
Change shebang

### DIFF
--- a/scripts/do
+++ b/scripts/do
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck source=../.venv/bin/activate
 
 # This is the base script to call all other commands


### PR DESCRIPTION
`/bin/bash` invokes `3.2.57(1)-release` on macOS, which doesn't support `-v`. Changing the shebang to `/usr/bin/env bash` uses the current environment, which (hopefully) has a more recent version of bash.

Closes #4