### PR TITLE
Prefer extend-exclude to exclude

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .direnv,.venv,venv
+extend-exclude = .direnv,.venv,venv
 ignore = \
     E501 \ # line too long (black fixes long lines, except for long strings which may benefit from being long (eg URLs))
     W503   # line break before binary operator (black disagrees)


### PR DESCRIPTION
I think we want to extend-exclude, because we also want to exclude the default glob patterns. Of these, the most relevant are `.git` and `__pycache__`. For more, see <https://flake8.pycqa.org/en/stable/user/options.html#cmdoption-flake8-exclude>.