### PR TITLE
Use black profile for isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,8 @@ skip_covered = true
 [tool.coverage.html]
 
 [tool.isort]
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 88
+profile = "black"
 lines_after_imports = 2
-multi_line_output = 3
 skip_glob = [".direnv", "venv", ".venv"]
-use_parentheses = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This uses the relatively new profile feature of isort so we can remove a few lines of config.  Since we added these lines to make black and isort play nicely this seems like an all around win.