### PR TITLE
Set a default python version for all pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,16 @@
+default_language_version:
+  python: python3.10
+
 repos:
   - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:
     - id: black
-      language_version: python3.10
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
     - id: flake8
-      language_version: python3.10
       additional_dependencies:
       - "flake8-builtins"
       - "flake8-implicit-str-concat"
@@ -19,7 +20,6 @@ repos:
     rev: 5.10.1
     hooks:
     - id: isort
-      language_version: python3.10
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0


### PR DESCRIPTION
pre-commit can set a [default language version](https://pre-commit.com/#top_level-default_language_version), which saves us adding it to every hook.