### PR TITLE
replace pytest-coverage with pytest-cov

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -13,4 +13,4 @@ isort
 pip-tools
 pre-commit
 pytest
-pytest-coverage
+pytest-cov


### PR DESCRIPTION
[pytest-coverage](https://pypi.org/project/pytest-coverage/) is a fork of pytest-cov and hasn't seen a release since 2015.