### PR TITLE
Remove dependency of tests on checks in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
         run: just check
 
   test:
-    needs: [check]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We've done this in several repos now, it tightens the loop for checking tests work and we've found it doesn't really add much to have the checks run as a prerequisite of tests.