### PR TITLE
Make it easier to use pyproject.toml OR requirements.prod.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ New repo checklist:
     manage.py:INP001
     gunicorn.conf.py:INP001
   ```
+- [ ] Will this project be installed with pip?
+  If so, delete `requirements.prod.in` and switch references in the `justfile` to `pyproject.toml`
 - [ ] Update DEVELOPERS.md with any project-specific requirements and commands
 - [ ] Update commands in `justfile`
 

--- a/justfile
+++ b/justfile
@@ -32,20 +32,21 @@ virtualenv:
     test -e $BIN/pip-compile || $PIP install pip-tools
 
 
-# update requirements.prod.txt if requirement.prod.in has changed
-requirements-prod: virtualenv
+_compile src dst *args: virtualenv
     #!/usr/bin/env bash
-    # exit if .in file is older than .txt file (-nt = 'newer than', but we negate with || to avoid error exit code)
-    test requirements.prod.in -nt requirements.prod.txt || exit 0
-    $COMPILE --output-file=requirements.prod.txt requirements.prod.in
+    # exit if src file is older than dst file (-nt = 'newer than', but we negate with || to avoid error exit code)
+    test "${FORCE:-}" = "true" -o {{ src }} -nt {{ dst }} || exit 0
+    $BIN/pip-compile --allow-unsafe --generate-hashes --output-file={{ dst }} {{ src }} {{ args }}
+
+
+# update requirements.prod.txt if requirements.prod.in has changed
+requirements-prod *args:
+    {{ just_executable() }} _compile requirements.prod.in requirements.prod.txt {{ args }}
 
 
 # update requirements.dev.txt if requirements.dev.in has changed
-requirements-dev: requirements-prod
-    #!/usr/bin/env bash
-    # exit if .in file is older than .txt file (-nt = 'newer than', but we negate with || to avoid error exit code)
-    test requirements.dev.in -nt requirements.dev.txt || exit 0
-    $COMPILE --output-file=requirements.dev.txt requirements.dev.in
+requirements-dev *args: requirements-prod
+    {{ just_executable() }} _compile requirements.dev.in requirements.dev.txt {{ args }}
 
 
 # ensure prod requirements installed and up to date
@@ -78,12 +79,12 @@ install-precommit:
     test -f $BASE_DIR/.git/hooks/pre-commit || $BIN/pre-commit install
 
 
-# upgrade dev or prod dependencies (all by default, specify package to upgrade single package)
+# upgrade dev or prod dependencies (specify package to upgrade single package, all by default)
 upgrade env package="": virtualenv
     #!/usr/bin/env bash
     opts="--upgrade"
     test -z "{{ package }}" || opts="--upgrade-package {{ package }}"
-    $COMPILE $opts --output-file=requirements.{{ env }}.txt requirements.{{ env }}.in
+    FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
 
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.


### PR DESCRIPTION
Some projects use requirements.prod.in to specify dependency specs,
others use pyproject.toml (typically these are pip-installable).  This
allows us to configure which file we want to use in the
requirements-prod target without having to use a conditional in the
upgrade target.