### PR TITLE
Use canonical URLs in `.pre-commit-config`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
     - id: black
 
-  - repo: https://github.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
     - id: flake8
@@ -16,7 +16,7 @@ repos:
       - "flake8-implicit-str-concat"
       - "flake8-no-pep420"
 
-  - repo: https://github.com/pycqa/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
     - id: isort


### PR DESCRIPTION
This appeases my fussiness.

The original URLs were all lowercase on GitLab, but not on GitHub.

Merely switching the domain works, because GitHub transparently treats
the URLs identically regardless of case. But the canonical URL is listed
in the source as below.