### PR TITLE
feat: automatically approve and merge dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yml
+++ b/.github/workflows/auto-merge-dependabot-prs.yml
@@ -1,0 +1,9 @@
+name: Auto merge Dependabot PRs
+
+on: pull_request
+
+jobs:
+  auto-merge-dependabot-prs:
+    uses: opensafely-core/.github/.github/workflows/auto-merge-dependabot-prs.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the Org-level workflow for auto-merging Dependabot PRs by default in our repos.

Fixes #68 