### PR TITLE
Remove unnecessary black config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ htmlcov
 # Virtual environments
 .venv/
 venv/
+
+.pytest-cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,3 @@
-[tool.black]
-exclude = '''
-(
-  /(
-      \.git         # exclude a few common directories
-    | \.direnv
-    | \.github
-    | \.pytest_cache
-    | \.venv
-    | htmlcov
-    | venv
-  )/
-)
-'''
-
 [tool.coverage.run]
 branch = true
 omit = [".venv/*"]


### PR DESCRIPTION
By default (according to --help as of v22.8.0) black is already ignoring this list of directories:

/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/

We were using --exclude which overwrote this list.  Black supports --extend-exclude which builds upon this list and also makes use of the repos .gitignore [1].  Since we we want both git and black to ignore the files for this repo can drop all black config here.

1: https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore

Fixes: opensafely-core/repo-template#85