### PR TITLE
Call our checks from the local venv in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,26 @@ default_language_version:
   python: python3.11
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: local
     hooks:
     - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
+      name: black
+      entry: just black
+      language: system
+      types: [python]
+      require_serial: true
     - id: flake8
-      additional_dependencies:
-      - "flake8-builtins"
-      - "flake8-implicit-str-concat"
-      - "flake8-no-pep420"
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
-    hooks:
+      name: flake8
+      entry: just flake8
+      language: system
+      types: [python]
+      require_serial: true
     - id: isort
+      name: isort
+      entry: just isort
+      language: system
+      types: [python]
+      require_serial: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/justfile
+++ b/justfile
@@ -93,11 +93,17 @@ test *args: devenv
     $BIN/coverage report || $BIN/coverage html
 
 
+black *args=".": devenv
+    $BIN/black --check {{ args }}
+
+isort *args=".": devenv
+    $BIN/isort --check-only --diff {{args}}
+
+flake8 *args="": devenv
+    $BIN/flake8 {{ args }}
+
 # runs the format (black), sort (isort) and lint (flake8) check but does not change any files
-check: devenv
-    $BIN/black --check .
-    $BIN/isort --check-only --diff .
-    $BIN/flake8
+check: black isort flake8
 
 
 # fix formatting and import sort ordering


### PR DESCRIPTION
pre-commit passes the paths of staged files to hooks so this splits up the checks into separate targets in the justfile (still grouped under the check target), with default args where necessary.