### PR TITLE
Remove Dependabot auto-merge function

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yml
+++ b/.github/workflows/auto-merge-dependabot-prs.yml
@@ -1,9 +1,0 @@
-name: Auto merge Dependabot PRs
-
-on: pull_request
-
-jobs:
-  auto-merge-dependabot-prs:
-    uses: opensafely-core/.github/.github/workflows/auto-merge-dependabot-prs.yml@main
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow gives the impression that any Dependabot changes are auto-deployed after being merged, but that's not currently the case. Rather than fixing it, we've decided that we will manually approve all Dependabot PRs, which will then be deployed as soon as we merge them.