### PR TITLE
Simplify recipe parameters

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,13 +41,11 @@ _compile src dst *args: virtualenv
 
 
 # update requirements.prod.txt if requirements.prod.in has changed
-requirements-prod *args:
-    "{{ just_executable() }}" _compile requirements.prod.in requirements.prod.txt {{ args }}
+requirements-prod *args: (_compile 'requirements.prod.in' 'requirements.prod.txt' args)
 
 
 # update requirements.dev.txt if requirements.dev.in has changed
-requirements-dev *args: requirements-prod
-    "{{ just_executable() }}" _compile requirements.dev.in requirements.dev.txt {{ args }}
+requirements-dev *args: requirements-prod (_compile 'requirements.dev.in' 'requirements.dev.txt' args)
 
 
 # ensure prod requirements installed and up to date

--- a/justfile
+++ b/justfile
@@ -48,31 +48,26 @@ requirements-prod *args: (_compile 'requirements.prod.in' 'requirements.prod.txt
 requirements-dev *args: requirements-prod (_compile 'requirements.dev.in' 'requirements.dev.txt' args)
 
 
-# ensure prod requirements installed and up to date
-prodenv: requirements-prod
+_install env:
     #!/usr/bin/env bash
     set -euo pipefail
 
     # exit if .txt file has not changed since we installed them (-nt == "newer than', but we negate with || to avoid error exit code)
-    test requirements.prod.txt -nt $VIRTUAL_ENV/.prod || exit 0
+    test requirements.{{ env }}.txt -nt $VIRTUAL_ENV/.{{ env }} || exit 0
 
-    $PIP install -r requirements.prod.txt
-    touch $VIRTUAL_ENV/.prod
+    $PIP install -r requirements.{{ env }}.txt
+    touch $VIRTUAL_ENV/.{{ env }}
+
+
+# ensure prod requirements installed and up to date
+prodenv: requirements-prod (_install 'prod')
 
 
 # && dependencies are run after the recipe has run. Needs just>=0.9.9. This is
 # a killer feature over Makefiles.
 #
 # ensure dev requirements installed and up to date
-devenv: prodenv requirements-dev && install-precommit
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # exit if .txt file has not changed since we installed them (-nt == "newer than', but we negate with || to avoid error exit code)
-    test requirements.dev.txt -nt $VIRTUAL_ENV/.dev || exit 0
-
-    $PIP install -r requirements.dev.txt
-    touch $VIRTUAL_ENV/.dev
+devenv: prodenv requirements-dev (_install 'dev') && install-precommit
 
 
 # ensure precommit is installed


### PR DESCRIPTION
While browsing the Just Programmer's Manual section on "[Recipe Parameters](https://just.systems/man/en/chapter_38.html)", I noticed that variables can be passed as arguments to dependencies. For example:

```sh
target := "main"

_build version:
  @echo 'Building {{version}}…'
  cd {{version}} && make

build: (_build target)
```

Extending the example, what if we wanted to save some typing by adding a `build-main` recipe?

```sh
_build version:
  @echo 'Building {{version}}…'
  cd {{version}} && make

build-main: (_build 'main')
```

We have a couple of pairs of recipes where we already save some typing: `requirements-prod`, `requirements-dev`, `prodenv`, and `devenv`. However, we do so by duplicating commands. In this PR, we remove some repetition by simplifying recipe parameters, just as we do in `build-main` above.