### PR TITLE
Replace dependabot with update-dependencies-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,26 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 23 * * *"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.11"
+        install-just: true
+
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: opensafely-core/update-dependencies-action@v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/justfile
+++ b/justfile
@@ -89,6 +89,13 @@ upgrade env package="": virtualenv
     FORCE=true "{{ just_executable() }}" requirements-{{ env }} $opts
 
 
+# Updgrade all dev and prod dependencies.
+# This is the default input command to update-depndencies action
+# https://github.com/opensafely-core/update-dependencies-action
+update-dependencies:
+    just upgrade prod
+    just upgrade dev
+
 # *args is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the tests
 test *args: devenv


### PR DESCRIPTION
Dependabot workflows have been broken for a while (e.g. [this run](https://github.com/opensafely-core/repo-template/actions/runs/11447629415)). This seems due to a https://github.com/dependabot/dependabot-core/issues/10631which is now happening on various repos (related to a variety of dependencies).

This replaces the python dependency updates with our custom update-dependencies-action, which updates all dependencies and opens a PR if necessary. We keep dependabot for Github Action updates only.