### PR TITLE
Pin `pip` to 25.0.1

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,8 +24,8 @@ virtualenv:
     # allow users to specify python version in .env
     PYTHON_VERSION=${PYTHON_VERSION:-$DEFAULT_PYTHON}
 
-    # create venv and upgrade pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
+    # create venv and install latest pip compatible with pip-tools
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.0.1; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -10,3 +10,6 @@ pre-commit
 pytest
 pyyaml
 ruff
+# Pin pip due to incompatibility of later releases with pip-tools
+# https://github.com/jazzband/pip-tools/issues/2176
+pip==25.0.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -223,7 +223,9 @@ wheel==0.45.1 \
 pip==25.0.1 \
     --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
     --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
-    # via pip-tools
+    # via
+    #   -r requirements.dev.in
+    #   pip-tools
 setuptools==79.0.0 \
     --hash=sha256:9828422e7541213b0aacb6e10bbf9dd8febeaa45a48570e09b6d100e063fc9f9 \
     --hash=sha256:b9ab3a104bedb292323f53797b00864e10e434a3ab3906813a7169e4745b912a


### PR DESCRIPTION
This fixes our update tooling.

As the comment states, the latest version of `pip` is incompatible with the latest released version of `pip-tools`:

https://github.com/jazzband/pip-tools/issues/2176

To unpin this, we need a fixed version of `pip-tools` to be available.

`pip` is pinned in two places, because there are two different entry points to run updates:

* in the `justfile`, because the CI workflow that updates dependencies uses the `just virtualenv` recipe to install `pip` and `pip-tools`
* in the `requirements.dev.in`, because local development environments set up or updated with `just devenv` will get the version of `pip` in `requirements.dev.txt`, and the version in `requirements.dev.txt` would get updated without pinning there

(Note that it does seem reasonable that the CI uses the base `just virtualenv` since it doesn't need all the development packages. We could consider consolidating these routes, though we've talked about using `uv` instead of `pip-tools`: `uv` likely makes simplifying this easy, because the only requirement for updating the packages is the single binary download of `uv`.)