### PR TITLE
Enable `uv` on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.11"
+          install-uv: true
           install-just: true
+          cache: uv
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -25,7 +27,9 @@ jobs:
       - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.11"
+          install-uv: true
           install-just: true
+          cache: uv
       - name: Run tests
 #       env:  # Add environment variables required for tests
         run: |


### PR DESCRIPTION
Note: this PR is pointed to the `switch-to-uv` branch as we probably do not want to merge into `main` just yet.

We have released [v1.6.1 of setup-action](https://github.com/opensafely-core/setup-action/releases/tag/v1.6.1), which includes an `install-uv` option.
Set this to true in the template, as we assume most python projects would like to use `uv` to manage dependencies.
We take advantage of the caching competencies of astral's setup-uv action for speedier CI runs, by setting `setup-action`'s `cache` param to "uv".