### PR TITLE
Switch to v2 of update-dependencies-action

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -21,6 +21,6 @@ jobs:
         app-id: 1031449  # opensafely-core Create PR app
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
-    - uses: bennettoxford/update-dependencies-action@v1
+    - uses: bennettoxford/update-dependencies-action@v2
       with:
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Draft PR as blocked on https://github.com/bennettoxford/update-dependencies-action/pull/42

v2 of `update-dependencies-action` includes a 7-day cooldown period in the default update command.
The cooldown period should be respected for dependency updates as per our Dependency Updates Policy.
I have chosen to switch to v2 of update-dependencies-action instead of keeping v1 and overriding the update command as this is the template for future new repos in the organisation, so it feels a bit wrong to use something other than the default input for a GHA that is owned by us.