### PR TITLE
Include uv in the update-dependencies workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: "opensafely-core/setup-action@v1"
       with:
         python-version: "3.13"
+        install-uv: true
         install-just: true
 
     - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
Workflow is [currently failing](https://github.com/opensafely-core/repo-template/actions/runs/18360282612/job/52302302655#step:5:28) because it needs uv