### PR TITLE
Ensure that tomlkit is using the correct version of python

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,7 +70,9 @@ upgrade-all: && devenv
 
 # Move the cutoff date in pyproject.toml to N days ago (default: 7) at midnight UTC
 bump-uv-cutoff days="7":
-    #!/usr/bin/env -S uvx --with tomlkit python3
+    #!/usr/bin/env -S uvx --with tomlkit python3.13
+    # Note we specify the python version here and we don't care if it's different to
+    # the .python-version; we need 3.11+ for the datetime code used.
 
     import datetime
     import tomlkit


### PR DESCRIPTION
Ensure that the bump-uv-cutoff recipe, which uses tomlkit, is using a sufficiently modern version of python. Otherwise it may fail in CI in unexpected ways when only the .python-version python is available.

The datetime code used (datetime.UTC and proper isoformat handling) is only available from 3.11. For this recipe, we don't care about being consistent with the .python-version, it's only calculating a timestamp to update in the pyproject.toml