### PR TITLE
Add a uv required-version to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ lines-after-imports = 2
 # Note: any `exclude-newer-package` timestamps should be removed if > 7 days old
 # See https://github.com/opensafely-core/repo-template/blob/main/DEVELOPERS.md for details
 [tool.uv]
+required-version = ">=0.9"
 exclude-newer = "2025-10-28T00:00:00Z"
 exclude-newer-package = {}
 


### PR DESCRIPTION
Ensures that local dev environments are using a modern enough version of uv for our just recipes.