### PR TITLE
Use `set default-list` and fix broken link

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,7 +4,7 @@
 
 ### just
 
-Follow installation instructions from the [Just Programmer's Manual](https://just.systems/man/en/chapter_4.html) for your OS.
+Follow installation instructions from the [Just documentation](https://github.com/casey/just#installation) for your OS.
 
 Add completion for your shell. E.g. for bash:
 ```

--- a/justfile
+++ b/justfile
@@ -1,9 +1,7 @@
 set dotenv-load := true
 set positional-arguments := true
-
 # List available commands
-default:
-    @"{{ just_executable() }}" --list
+set default-list := true  # requires just executable version >= 1.52.0
 
 # Create a valid .env if none exists
 _dotenv:


### PR DESCRIPTION
Use the built-in `default-list` option rather than our own just recipe. This requires at least version 1.52.0. This requires version 1.52.0, which seems reasonable to require for new repositories. It was released 2026-06-09.

Fix broken link to the `just` manual.